### PR TITLE
Fix TypeError on first write attempt to ShmMap

### DIFF
--- a/src/ShmMap.php
+++ b/src/ShmMap.php
@@ -204,7 +204,13 @@ class ShmMap implements ShmMapInterface, \ArrayAccess, \Countable, \IteratorAggr
             return [];
         }
 
-        return unserialize(trim($read), ['allowed_classes' => false]);
+        $map = unserialize(trim($read), ['allowed_classes' => false]);
+
+        if (!is_array($map)) {
+            $map = [];
+        }
+
+        return $map;
     }
 
     /**


### PR DESCRIPTION
Just running your sample from project description and got an error:
> TypeError: Return value of PhpComp\Shm\ShmMap::getMap() must be of the type array, boolean returned in <...>[\php-comp\shm\src\ShmMap.php on line 207](https://github.com/php-comp/shared-memory/blob/master/src/ShmMap.php#L207)

According to [unserialize documentation](http://php.net/manual/en/function.unserialize.php) it returns `mixed` type. 

So better to check unserialize result type and if it not an array, then create new empty one.